### PR TITLE
Quick code optimizations

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -138,7 +138,7 @@ fn create_test_tokenizer() -> Result<Tekkenizer> {
     Tekkenizer::new(
         vocab,
         &special_tokens,
-        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+".to_string(),
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+",
         300, // vocab_size
         100, // num_special_tokens
         config::TokenizerVersion::V7,

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,7 @@ pub struct ModelData {
 /// * `V7` - Version with enhanced special tokens and audio support
 /// * `V11` - Updated version with additional features
 /// * `V13` - Latest version with full multimodal capabilities
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenizerVersion {
     V3,
     V7,
@@ -146,7 +146,7 @@ impl TokenizerVersion {
     /// assert_eq!(TokenizerVersion::V13.as_str(), "v13");
     /// ```
     #[must_use]
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::V3 => "v3",
             Self::V7 => "v7",

--- a/src/special_tokens.rs
+++ b/src/special_tokens.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// - **Audio tokens**: Audio, `BeginAudio`, Transcribe for audio content
 /// - **Code tokens**: Prefix, Middle, Suffix for code completion
 /// - **System tokens**: `BeginSystem`, `EndSystem` for system prompts
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SpecialTokens {
     Unk,
     Bos,
@@ -65,7 +65,7 @@ impl SpecialTokens {
     /// assert_eq!(SpecialTokens::BeginAudio.as_str(), "[BEGIN_AUDIO]");
     /// ```
     #[must_use]
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Unk => "<unk>",
             Self::Bos => "<s>",
@@ -125,7 +125,7 @@ impl SpecialTokens {
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecialTokenPolicy {
     /// Skip special tokens during decoding, excluding them from the output.
     Ignore,

--- a/tests/test_full_vocab_profile.rs
+++ b/tests/test_full_vocab_profile.rs
@@ -44,7 +44,7 @@ fn test_full_vocab_profile() {
     let tokenizer = Tekkenizer::new(
         model_data.vocab,
         &special_tokens,
-        config.pattern,
+        &config.pattern,
         config.default_vocab_size,
         config.default_num_special_tokens,
         tekken::config::TokenizerVersion::from_string(&config.version)

--- a/tests/test_profile_loading.rs
+++ b/tests/test_profile_loading.rs
@@ -44,7 +44,7 @@ fn test_profile_loading() {
     let tokenizer = Tekkenizer::new(
         small_vocab,
         &special_tokens,
-        config.pattern,
+        &config.pattern,
         1000 + config.default_num_special_tokens,
         config.default_num_special_tokens,
         tekken::config::TokenizerVersion::from_string(&config.version)

--- a/tests/test_small_vocab.rs
+++ b/tests/test_small_vocab.rs
@@ -59,7 +59,7 @@ fn test_small_vocab() {
     let tokenizer = Tekkenizer::new(
         vocab,
         &special_tokens,
-        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+".to_string(),
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+",
         268, // vocab_size (258 + 10)
         10,  // num_special_tokens
         TokenizerVersion::V7,


### PR DESCRIPTION
Improve API ergonomics and add const correctness

  ## Summary
  - Make simple getter methods `const fn` for compile-time usage
  - Add `Eq` trait where `PartialEq` is derived for completeness
  - Use `map_or_else` for cleaner Option handling
  - Change `pattern` parameter from `String` to `&str` in `new()` for better API
  ergonomics